### PR TITLE
Fixes a null pointer issue.

### DIFF
--- a/assets/javascripts/libs/jquery.jeditable.ptext.js
+++ b/assets/javascripts/libs/jquery.jeditable.ptext.js
@@ -1,7 +1,8 @@
 $.editable.addInputType('ptext', {
     element : function(settings, original)
     {
-        var input = $('<input type="text"/>');
+        var input = $(document.createElement('input'));
+        input.attr('type','text');
         if (settings.width  != 'none') { input.attr('width', settings.width);  }
         if (settings.height != 'none') { input.attr('height', settings.height); }
         input.attr('autocomplete','off');

--- a/assets/javascripts/libs/jquery.jeditable.ptext.js
+++ b/assets/javascripts/libs/jquery.jeditable.ptext.js
@@ -8,7 +8,6 @@ $.editable.addInputType('ptext', {
         input.attr('autocomplete','off');
         input.attr('placeholder', settings.placeholder);
         $(this).append(input);
-        input.textPlaceholder();
         return input;
     }
 });


### PR DESCRIPTION
The input never got created, therefor you'd get a null pointer exception in line 5 which is now line 6.
$('<tag></tag>') is not just slower but doesn't allow any attributes.
This should be faster and work just fine in any browser.
