### PR TITLE
Add trackers.name to tasks showing on Sprints page. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea
 .svn
+*.iml

--- a/app/models/sprints_tasks.rb
+++ b/app/models/sprints_tasks.rb
@@ -37,7 +37,7 @@ class SprintsTasks < Issue
         cond << sprint
       end
     end
-    SprintsTasks.find(:all, :order => SprintsTasks::ORDER, :conditions => cond, :joins => :status, :include => :assigned_to).each{|task| tasks << task}
+    SprintsTasks.find(:all, :select => 'issues.*, trackers.name AS t_name', :order => SprintsTasks::ORDER, :conditions => cond, :joins => :status, :joins => "left join issue_statuses on issue_statuses.id = status_id left join trackers on trackers.id = tracker_id", :include => :assigned_to).each{|task| tasks << task}
     return tasks
   end
 

--- a/app/models/sprints_tasks.rb
+++ b/app/models/sprints_tasks.rb
@@ -21,8 +21,8 @@ class SprintsTasks < Issue
       user = User.current.id if user == 'current'
       cond << user
     end
-    SprintsTasks.find(:all, :select => 'issues.*, sum(hours) as spent', :order => SprintsTasks::ORDER, :conditions => cond, :group => "issues.id",
-                      :joins => [:status], :joins => "left join time_entries ON time_entries.issue_id = issues.id", :include => [:assigned_to]).each{|task| tasks << task}
+    SprintsTasks.find(:all, :select => 'issues.*, sum(hours) as spent, trackers.name AS t_name', :order => SprintsTasks::ORDER, :conditions => cond, :group => "issues.id",
+                      :joins => [:status], :joins => "left join time_entries ON time_entries.issue_id = issues.id left join trackers on trackers.id = tracker_id", :include => [:assigned_to]).each{|task| tasks << task}
     return tasks
   end
 

--- a/app/views/adsprints/_task.html.erb
+++ b/app/views/adsprints/_task.html.erb
@@ -1,6 +1,7 @@
 <div id="task.<%=h task.id %>" class="sc_task <%= @closed_status == task.status_id ? 'closed_task' : '' %>">
   <div class="fl task_no">#<%= link_to task.id, :controller => 'issues', :action => 'show', :id => task %></div>
   <div class="fl task_desc"><img src="<%= File.join(@plugin_path, 'images', 'task_desc.png') %>"/></div>
+  <div class="fl task_tracker_name"><%=h task.t_name %>&nbsp;-&nbsp;</div>
   <div class="task_subject"><%=h task.subject %></div>
   <div class="task_estimate fl"><%=h task.estimated_hours || l(:label_sprints_placeholder_estimated) %></div>
   <div class="task_owner fr"><%=h task.assigned_to %></div>

--- a/app/views/adtasks/_task.html.erb
+++ b/app/views/adtasks/_task.html.erb
@@ -1,6 +1,7 @@
 <div id="task.<%=h task.id %>" class="sc_task">
   <div class="fl task_no">#<%= link_to task.id, :controller => 'issues', :action => 'show', :id => task %></div>
   <div class="fl task_desc"><img src="<%= File.join(@plugin_path, 'images', 'task_desc.png') %>"/></div>
+  <div class="fl task_tracker_name"><%=h task.t_name %>&nbsp;-&nbsp;</div>
   <div class="task_subject" title="<%=h task.subject %>"><%=h task.subject %></div>
   <div class="task_row">
       <div class="task_doneratio_slide"></div>

--- a/assets/javascripts/burndown.js
+++ b/assets/javascripts/burndown.js
@@ -45,7 +45,7 @@ var Burndown = function ($)
         {
             if (!tasks.hasOwnProperty(id))
                 continue;
-            tasks[id].created_on = Date.fromMysql(tasks[id].created_on);
+            tasks[id].sprints_tasks.created_on = Date.fromMysql(tasks[id].sprints_tasks.created_on);
         }
         // loop through changes
         for (i = 0, len = changes.length; i < len; )
@@ -59,7 +59,7 @@ var Burndown = function ($)
             {
                 if (!tasks.hasOwnProperty(id))
                     continue;
-                var task = tasks[id];
+                var task = tasks[id].sprints_tasks;
                 // delete tasks, that was created after current date
                 if (task.created_on > dateTime)
                     delete tasks[id];
@@ -76,9 +76,9 @@ var Burndown = function ($)
             while (dateTime == changeDate)
             {
                 if (changes[i].prop_key == 'done_ratio')
-                    tasks[changes[i].issueId].done_ratio = changes[i].value;
+                    tasks[changes[i].issueId].sprints_tasks.done_ratio = changes[i].value;
                 else
-                    tasks[changes[i].issueId].estimated_hours = changes[i].value;
+                    tasks[changes[i].issueId].sprints_tasks.estimated_hours = changes[i].value;
                 // next change
                 i++;
                 if (i >= len)

--- a/init.rb
+++ b/init.rb
@@ -22,7 +22,9 @@ Redmine::Plugin.register :AgileDwarf do
 
   project_module :scrum do
     permission :sprints, {:adsprints => [:list], :adtaskinl => [:update, :inplace, :create, :tooltip], :adsprintinl => [:create, :inplace]}
+    permission :sprints_readonly, {:adsprints => [:list]}
     permission :sprints_tasks, {:adtasks => [:list], :adtaskinl => [:update, :inplace, :tooltip, :spent]}
+    permission :sprints_tasks_readonly, {:adtasks => [:list]}
     permission :burndown_charts, {:adburndown => [:show]}
   end
 


### PR DESCRIPTION
Hello,

Our team wanted to see the tracker_id value shown on the tasks on the Sprints page. This pull request includes the changes I made to show the tracker_id value joined to the human readable trackers.name value. 
If this is useful for others, great. If not and you would rather not merge the change then that is fine too. There may be a better way to write the query. I do not know Ruby so I winged it. 

Best Regards,
Ric
