### PR TITLE
Setting hash fixed

### DIFF
--- a/app/controllers/adsprints_controller.rb
+++ b/app/controllers/adsprints_controller.rb
@@ -11,7 +11,7 @@ class AdsprintsController < ApplicationController
     @project.assignable_users.each{|u| @assignables[u.id] = u.firstname + ' ' + u.lastname}
     @project_id = @project.id
     @plugin_path = File.join(Redmine::Utils.relative_url_root, 'plugin_assets', 'AgileDwarf')
-    @closed_status = Setting.plugin_AgileDwarf[:stclosed].to_i
+    @closed_status = Setting.plugin_AgileDwarf["stclosed"].to_i
   end
 
   private

--- a/app/controllers/adtaskinl_controller.rb
+++ b/app/controllers/adtaskinl_controller.rb
@@ -23,7 +23,7 @@ class AdtaskinlController < ApplicationController
   def create
     attribs = params.select{|k,v| k != 'id' and SprintsTasks.column_names.include? k }
     attribs = Hash[*attribs.flatten]
-    attribs['tracker_id'] = attribs['tracker_id'] || Setting.plugin_AgileDwarf[:tracker]
+    attribs['tracker_id'] = attribs['tracker_id'] || Setting.plugin_AgileDwarf['tracker']
     attribs['author_id'] = User.current.id
     task = SprintsTasks.new(attribs)
     begin
@@ -50,7 +50,7 @@ class AdtaskinlController < ApplicationController
   end
 
   def spent
-    spenttime = TimeEntry.new({:hours => params[:hours], :activity_id => Setting.plugin_AgileDwarf[:activity], :user => User.current, :project => @project, :spent_on => Date.today,
+    spenttime = TimeEntry.new({:hours => params[:hours], :activity_id => Setting.plugin_AgileDwarf["activity"], :user => User.current, :project => @project, :spent_on => Date.today,
                                :issue_id => params[:id]})
     begin
       spenttime.save!

--- a/app/controllers/adtasks_controller.rb
+++ b/app/controllers/adtasks_controller.rb
@@ -25,11 +25,10 @@ class AdtasksController < ApplicationController
     user = nil if @user == 'all'
 
     @plugin_path = File.join(Redmine::Utils.relative_url_root, 'plugin_assets', 'AgileDwarf')
-
     status_ids = []
-    colcount = Setting.plugin_AgileDwarf[:stcolumncount].to_i
+    colcount = Setting.plugin_AgileDwarf['stcolumncount'].to_i
     for i in 1 .. colcount
-      status_ids << Setting.plugin_AgileDwarf[('stcolumn' + i.to_s).to_sym].to_i
+      status_ids << Setting.plugin_AgileDwarf[('stcolumn' + i.to_s)].to_i
     end
     @statuses = {}
     IssueStatus.find_all_by_id(status_ids).each {|x| @statuses[x.id] = x.name}

--- a/app/views/adsprints/_task.html.erb
+++ b/app/views/adsprints/_task.html.erb
@@ -1,4 +1,4 @@
-<div id="task.<%=h task.id %>" class="sc_task sc_task_cat_<%= task.category_id %> <%= @closed_status == task.status_id ? 'closed_task' : '' %>">
+<div id="task.<%=h task.id %>" class="sc_task sc_task_tracker_<%= Tracker.find(task.tracker_id).name %>  <%= task.children.count  == 0 or Tracker.find(task.tracker_id).name != 'UserStorie' ? '' : 'sc_task_hide' %> <%= @closed_status == task.status_id ? 'closed_task' : '' %>">
   <div class="fl task_no">#<%= link_to task.id, :controller => 'issues', :action => 'show', :id => task %></div>
   <div class="fl task_desc"><img src="<%= File.join(@plugin_path, 'images', 'task_desc.png') %>"/></div>
   <div class="task_subject"><%=h task.subject %></div>

--- a/app/views/adsprints/_task.html.erb
+++ b/app/views/adsprints/_task.html.erb
@@ -1,4 +1,4 @@
-<div id="task.<%=h task.id %>" class="sc_task <%= @closed_status == task.status_id ? 'closed_task' : '' %>">
+<div id="task.<%=h task.id %>" class="sc_task sc_task_cat_<%= task.category_id %> <%= @closed_status == task.status_id ? 'closed_task' : '' %>">
   <div class="fl task_no">#<%= link_to task.id, :controller => 'issues', :action => 'show', :id => task %></div>
   <div class="fl task_desc"><img src="<%= File.join(@plugin_path, 'images', 'task_desc.png') %>"/></div>
   <div class="task_subject"><%=h task.subject %></div>

--- a/app/views/adtasks/_task.html.erb
+++ b/app/views/adtasks/_task.html.erb
@@ -1,4 +1,4 @@
-<div id="task.<%=h task.id %>" class="sc_task">
+<div id="task.<%=h task.id %>" class="sc_task  sc_task_tracker_<%= Tracker.find(task.tracker_id).name %> <%= task.children.count %> <%= task.children.count  == 0 ? '' : 'sc_task_hide' %>">
   <div class="fl task_no">#<%= link_to task.id, :controller => 'issues', :action => 'show', :id => task %></div>
   <div class="fl task_desc"><img src="<%= File.join(@plugin_path, 'images', 'task_desc.png') %>"/></div>
   <div class="task_subject" title="<%=h task.subject %>"><%=h task.subject %></div>

--- a/app/views/adtasks/_task.html.erb
+++ b/app/views/adtasks/_task.html.erb
@@ -1,4 +1,4 @@
-<div id="task.<%=h task.id %>" class="sc_task  sc_task_tracker_<%= Tracker.find(task.tracker_id).name %> <%= task.children.count %> <%= task.children.count  == 0 ? '' : 'sc_task_hide' %>">
+<div id="task.<%=h task.id %>" class="sc_task  sc_task_tracker_<%= Tracker.find(task.tracker_id).name %>  <%= task.children.count  == 0 or Tracker.find(task.tracker_id).name != 'UserStorie' ? '' : 'sc_task_hide' %>">
   <div class="fl task_no">#<%= link_to task.id, :controller => 'issues', :action => 'show', :id => task %></div>
   <div class="fl task_desc"><img src="<%= File.join(@plugin_path, 'images', 'task_desc.png') %>"/></div>
   <div class="task_subject" title="<%=h task.subject %>"><%=h task.subject %></div>

--- a/app/views/shared/_settings.html.erb
+++ b/app/views/shared/_settings.html.erb
@@ -3,47 +3,47 @@
 
 <p>
   <%= content_tag(:label, l(:label_settings_tracker)) %>
-  <%= select_tag("settings[tracker]", options_from_collection_for_select(Tracker.all, :id, :name, Setting.plugin_AgileDwarf[:tracker].to_i)) %>
+  <%= select_tag("settings[tracker]", options_from_collection_for_select(Tracker.all, :id, :name, Setting.plugin_AgileDwarf['tracker'].to_i)) %>
 </p>
 
 <p>
   <%= content_tag(:label, l(:label_settings_activity)) %>
-  <%= select_tag("settings[activity]", options_from_collection_for_select(TimeEntryActivity.all, :id, :name, Setting.plugin_AgileDwarf[:activity].to_i)) %>
+  <%= select_tag("settings[activity]", options_from_collection_for_select(TimeEntryActivity.all, :id, :name, Setting.plugin_AgileDwarf['activity'].to_i)) %>
 </p>
 
 <p>
   <%= content_tag(:label, l(:label_settings_closedstatus)) %>
-  <%= select_tag("settings[stclosed]", options_from_collection_for_select(IssueStatus.all, :id, :name, Setting.plugin_AgileDwarf[:stclosed].to_i)) %>
+  <%= select_tag("settings[stclosed]", options_from_collection_for_select(IssueStatus.all, :id, :name, Setting.plugin_AgileDwarf['stclosed'].to_i)) %>
 </p>
 
 <p>
   <%= content_tag(:label, l(:label_settings_columncount)) %>
-  <%= select_tag("settings[stcolumncount]", options_for_select([2, 3, 4, 5], Setting.plugin_AgileDwarf[:stcolumncount].to_i)) %>
+  <%= select_tag("settings[stcolumncount]", options_for_select([2, 3, 4, 5], Setting.plugin_AgileDwarf['stcolumncount'].to_i)) %>
 </p>
 
 <div id="stcolumns">
     <p>
       <%= content_tag(:label, l(:label_settings_column1status)) %>
-      <%= select_tag("settings[stcolumn1]", options_from_collection_for_select(IssueStatus.all, :id, :name, Setting.plugin_AgileDwarf[:stcolumn1].to_i)) %>
+      <%= select_tag("settings[stcolumn1]", options_from_collection_for_select(IssueStatus.all, :id, :name, Setting.plugin_AgileDwarf['stcolumn1'].to_i)) %>
     </p>
 
     <p>
       <%= content_tag(:label, l(:label_settings_column2status)) %>
-      <%= select_tag("settings[stcolumn2]", options_from_collection_for_select(IssueStatus.all, :id, :name, Setting.plugin_AgileDwarf[:stcolumn2].to_i)) %>
+      <%= select_tag("settings[stcolumn2]", options_from_collection_for_select(IssueStatus.all, :id, :name, Setting.plugin_AgileDwarf['stcolumn2'].to_i)) %>
     </p>
 
     <p>
       <%= content_tag(:label, l(:label_settings_column3status)) %>
-      <%= select_tag("settings[stcolumn3]", options_from_collection_for_select(IssueStatus.all, :id, :name, Setting.plugin_AgileDwarf[:stcolumn3].to_i)) %>
+      <%= select_tag("settings[stcolumn3]", options_from_collection_for_select(IssueStatus.all, :id, :name, Setting.plugin_AgileDwarf['stcolumn3'].to_i)) %>
     </p>
 
     <p>
       <%= content_tag(:label, l(:label_settings_column4status)) %>
-      <%= select_tag("settings[stcolumn4]", options_from_collection_for_select(IssueStatus.all, :id, :name, Setting.plugin_AgileDwarf[:stcolumn4].to_i)) %>
+      <%= select_tag("settings[stcolumn4]", options_from_collection_for_select(IssueStatus.all, :id, :name, Setting.plugin_AgileDwarf['stcolumn4'].to_i)) %>
     </p>
 
     <p>
       <%= content_tag(:label, l(:label_settings_column5status)) %>
-      <%= select_tag("settings[stcolumn5]", options_from_collection_for_select(IssueStatus.all, :id, :name, Setting.plugin_AgileDwarf[:stcolumn5].to_i)) %>
+      <%= select_tag("settings[stcolumn5]", options_from_collection_for_select(IssueStatus.all, :id, :name, Setting.plugin_AgileDwarf['stcolumn5'].to_i)) %>
     </p>
 </div>

--- a/assets/javascripts/burndown.js
+++ b/assets/javascripts/burndown.js
@@ -66,7 +66,8 @@ var Burndown = function ($)
                 else
                 {
                     // rest of work = ((100 - done_ratio) * estimate) / 100
-                    sum += ((100 - task.done_ratio) * (task.estimated_hours || 0)) / 100;
+                    console.log(task.sprints_tasks.done_ratio);
+                    sum += ((100 - task.sprints_tasks.done_ratio) * (task.sprints_tasks.estimated_hours || 0)) / 100;
                 }
             }
             // add new point to series

--- a/assets/javascripts/libs/jquery.jeditable.ptext.js
+++ b/assets/javascripts/libs/jquery.jeditable.ptext.js
@@ -7,7 +7,6 @@ $.editable.addInputType('ptext', {
         input.attr('autocomplete','off');
         input.attr('placeholder', settings.placeholder);
         $(this).append(input);
-        input.textPlaceholder();
         return input;
     }
 });

--- a/assets/javascripts/libs/jquery.jeditable.ptext.js
+++ b/assets/javascripts/libs/jquery.jeditable.ptext.js
@@ -1,7 +1,8 @@
 $.editable.addInputType('ptext', {
     element : function(settings, original)
     {
-        var input = $('<input type="text"/>');
+        var input = $(document.createElement('input'));
+        input.attr('type','text');
         if (settings.width  != 'none') { input.attr('width', settings.width);  }
         if (settings.height != 'none') { input.attr('height', settings.height); }
         input.attr('autocomplete','off');

--- a/assets/javascripts/libs/jquery.jeditable.ptext.js
+++ b/assets/javascripts/libs/jquery.jeditable.ptext.js
@@ -8,7 +8,6 @@ $.editable.addInputType('ptext', {
         input.attr('autocomplete','off');
         input.attr('placeholder', settings.placeholder);
         $(this).append(input);
-        input.textPlaceholder();
         return input;
     }
 });

--- a/assets/stylesheets/sprints.css
+++ b/assets/stylesheets/sprints.css
@@ -89,6 +89,7 @@
 .task_list .sc_task.sc_task_tracker_UserStorie
 {
     border-color: #276DFA;
+    background: rgba(39, 109, 250, 0.3);
     box-shadow: 0 0 4px #276DFA;
     -moz-box-shadow: 0 0 4px #276DFA;
     -ms-box-shadow: 0 0 4px #276DFA;

--- a/assets/stylesheets/sprints.css
+++ b/assets/stylesheets/sprints.css
@@ -80,6 +80,22 @@
     -webkit-box-shadow: 0 0 4px #1f6993;
 }
 
+
+.task_list .sc_task_hide
+{
+    display:None;
+}
+
+.task_list .sc_task.sc_task_tracker_UserStorie
+{
+    border-color: #276DFA;
+    box-shadow: 0 0 4px #276DFA;
+    -moz-box-shadow: 0 0 4px #276DFA;
+    -ms-box-shadow: 0 0 4px #276DFA;
+    -o-box-shadow: 0 0 4px #276DFA;
+    -webkit-box-shadow: 0 0 4px #276DFA;
+}
+
 .task_list
 {
     margin: 0;


### PR DESCRIPTION
The latest commit fixes three issues I was having. 

1) When trying to add a task from the Sprint page, it would throw a javascript error saying that a tracker wasn't found.
2) When trying to list tasks on the Task page, nothing would show up.
3) When in the settings menu for AgileDwarf, the settings wouldn't stick after setting them.

I traced this down to the fact that the settings hash as stored in the Setting model had strings for the keys rather than symbols. When I changed all the keys from symbols to strings, the problems all went away.

My Environment:

Environment:
  Redmine version                          2.2.3.stable
  Ruby version                             1.9.2 (i686-linux)
  Rails version                            3.2.12
  Environment                              production
  Database adapter                         Mysql2
Redmine plugins:
  AgileDwarf                               0.0.3
