### PR TITLE
Fix README so rake task will work.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ OR instead of downloading and unpacking
 
 In #{RAILS_ROOT} run the command
 
-    rake redmine:plugins:migrate
+    rake RAILS_ENV=production redmine:plugins:migrate
   
 Restart Redmine
  


### PR DESCRIPTION
Without this patch, someone following the README cannot get the software
to work as the rake task will fail without setting the RAILS_ENV. This
updates the README with the correct command.
